### PR TITLE
Fix issue where pylut refuses to resize a LUT

### DIFF
--- a/pylut/pylut.py
+++ b/pylut/pylut.py
@@ -426,7 +426,7 @@ class LUT:
 		if redPoint > cubeSize-1 or greenPoint > cubeSize-1 or bluePoint > cubeSize-1:
 			raise NameError("Point Out of Bounds: (" + str(redPoint) + ", " + str(greenPoint) + ", " + str(bluePoint) + ")")
 
-		return self.lattice[redPoint, greenPoint, bluePoint]
+		return self.lattice[int(redPoint), int(greenPoint), int(bluePoint)]
 
 	#float input from 0 to cubeSize-1
 	def ColorAtInterpolatedLatticePoint(self, redPoint, greenPoint, bluePoint):


### PR DESCRIPTION
Somehow some floats (65.0 instead of 65, for example) were making their way into ColorAtLatticePoint when I was resizing from x64 to x17. Doing an explicit cast fixed the issue.

It was throwing this error:

```
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```