### PR TITLE
Fixed an issue in ColorAtInterpolatedLatticePoint Function where inde…

### DIFF
--- a/pylut/pylut.py
+++ b/pylut/pylut.py
@@ -446,6 +446,15 @@ class LUT:
 
 		lowerBluePoint = Clamp(int(math.floor(bluePoint)), 0, cubeSize-1)
 		upperBluePoint = Clamp(lowerBluePoint + 1, 0, cubeSize-1)
+		
+		lowerRedPoint=int (lowerRedPoint)
+		upperRedPoint=int (upperRedPoint)
+		
+		lowerGreenPoint=int (lowerGreenPoint)
+		upperGreenPoint=int (upperGreenPoint)
+		
+		lowerBluePoint=int (lowerBluePoint)
+		upperBluePoint=int (upperBluePoint)
 
 		C000 = self.ColorAtLatticePoint(lowerRedPoint, lowerGreenPoint, lowerBluePoint)
 		C010 = self.ColorAtLatticePoint(lowerRedPoint, lowerGreenPoint, upperBluePoint)

--- a/pylut/pylut.py
+++ b/pylut/pylut.py
@@ -447,14 +447,14 @@ class LUT:
 		lowerBluePoint = Clamp(int(math.floor(bluePoint)), 0, cubeSize-1)
 		upperBluePoint = Clamp(lowerBluePoint + 1, 0, cubeSize-1)
 		
-		lowerRedPoint=int (lowerRedPoint)
-		upperRedPoint=int (upperRedPoint)
+		lowerRedPoint = int(lowerRedPoint)
+		upperRedPoint = int(upperRedPoint)
 		
-		lowerGreenPoint=int (lowerGreenPoint)
-		upperGreenPoint=int (upperGreenPoint)
+		lowerGreenPoint = int(lowerGreenPoint)
+		upperGreenPoint = int(upperGreenPoint)
 		
-		lowerBluePoint=int (lowerBluePoint)
-		upperBluePoint=int (upperBluePoint)
+		lowerBluePoint = int(lowerBluePoint)
+		upperBluePoint = int(upperBluePoint)
 
 		C000 = self.ColorAtLatticePoint(lowerRedPoint, lowerGreenPoint, lowerBluePoint)
 		C010 = self.ColorAtLatticePoint(lowerRedPoint, lowerGreenPoint, upperBluePoint)

--- a/pylut/pylut.py
+++ b/pylut/pylut.py
@@ -453,7 +453,7 @@ class LUT:
 		lowerGreenPoint = int(lowerGreenPoint)
 		upperGreenPoint = int(upperGreenPoint)
 		
-		lowerBluePoint = int(lowerBluePoint)
+		lowerBluePoint =int(lowerBluePoint)
 		upperBluePoint = int(upperBluePoint)
 
 		C000 = self.ColorAtLatticePoint(lowerRedPoint, lowerGreenPoint, lowerBluePoint)

--- a/pylut/pylut.py
+++ b/pylut/pylut.py
@@ -453,7 +453,7 @@ class LUT:
 		lowerGreenPoint = int(lowerGreenPoint)
 		upperGreenPoint = int(upperGreenPoint)
 		
-		lowerBluePoint =int(lowerBluePoint)
+		lowerBluePoint = int(lowerBluePoint)
 		upperBluePoint = int(upperBluePoint)
 
 		C000 = self.ColorAtLatticePoint(lowerRedPoint, lowerGreenPoint, lowerBluePoint)


### PR DESCRIPTION
…x values become float

In  ColorAtInterpolatedLatticePoint Function, the index values  lowerRedPoint, upperRedPoint, lowerGreenPoint, upperGreenPoint, lowerBluePoint, upperBluePoint sometimes becoming float values such as 15.0. So I converted those values to int type.  

After doing so, the issue posted by user Junnu123 "Error Combining LUT" is also resolved .